### PR TITLE
client_id and scope validations

### DIFF
--- a/lib/grant/codeIdToken.js
+++ b/lib/grant/codeIdToken.js
@@ -57,6 +57,7 @@ module.exports = function(options, issueCode, issueIDToken) {
       , state = req.query['state'];
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/grant/codeIdToken.js
+++ b/lib/grant/codeIdToken.js
@@ -60,6 +60,10 @@ module.exports = function(options, issueCode, issueIDToken) {
     if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+      }
+      
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/grant/codeIdTokenToken.js
+++ b/lib/grant/codeIdTokenToken.js
@@ -63,6 +63,10 @@ module.exports = function(options, issueToken, issueCode, issueIDToken) {
     if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+      }
+      
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/grant/codeIdTokenToken.js
+++ b/lib/grant/codeIdTokenToken.js
@@ -60,6 +60,7 @@ module.exports = function(options, issueToken, issueCode, issueIDToken) {
       , state = req.query['state'];
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/grant/codeToken.js
+++ b/lib/grant/codeToken.js
@@ -58,6 +58,7 @@ module.exports = function(options, issueToken, issueCode) {
       , state = req.query['state'];
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       for (var i = 0, len = separators.length; i < len; i++) {

--- a/lib/grant/codeToken.js
+++ b/lib/grant/codeToken.js
@@ -61,6 +61,10 @@ module.exports = function(options, issueToken, issueCode) {
     if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
+      if (typeof scope !== 'string') {
+        throw new AuthorizationError('Invalid parameter: scope must be a string', 'invalid_request');
+      }
+      
       for (var i = 0, len = separators.length; i < len; i++) {
         var separated = scope.split(separators[i]);
         // only separate on the first matching separator.  this allows for a sort

--- a/lib/grant/idToken.js
+++ b/lib/grant/idToken.js
@@ -54,6 +54,7 @@ module.exports = function(options, issue) {
       , state = req.query['state'];
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       if (typeof scope !== 'string') {

--- a/lib/grant/idTokenToken.js
+++ b/lib/grant/idTokenToken.js
@@ -57,6 +57,7 @@ module.exports = function(options, issueToken, issueIDToken) {
       , state = req.query['state'];
       
     if (!clientID) { throw new AuthorizationError('Missing required parameter: client_id', 'invalid_request'); }
+    if (typeof clientID !== 'string') { throw new AuthorizationError('Invalid parameter: client_id must be a string', 'invalid_request'); }
     
     if (scope) {
       if (typeof scope !== 'string') {

--- a/test/grant/codeIdToken.test.js
+++ b/test/grant/codeIdToken.test.js
@@ -290,6 +290,34 @@ describe('grant.codeIdToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('with scope parameter that is not a string', function() {
+      var err, out;
+
+      before(function(done) {
+        chai.oauth2orize.grant(codeIdToken(issueCode, issueIDToken))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = 'c123';
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+            req.query.scope = ['read', 'write'];
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: scope must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
 

--- a/test/grant/codeIdToken.test.js
+++ b/test/grant/codeIdToken.test.js
@@ -263,6 +263,33 @@ describe('grant.codeIdToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(codeIdToken(issueCode, issueIDToken))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
 

--- a/test/grant/codeIdTokenToken.test.js
+++ b/test/grant/codeIdTokenToken.test.js
@@ -297,6 +297,34 @@ describe('grant.codeIdTokenToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('with scope parameter that is not a string', function() {
+      var err, out;
+
+      before(function(done) {
+        chai.oauth2orize.grant(codeIdTokenToken(issueToken, issueCode, issueIDToken))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = 'c123';
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+            req.query.scope = ['read', 'write'];
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: scope must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
   describe('decision handling', function() {

--- a/test/grant/codeIdTokenToken.test.js
+++ b/test/grant/codeIdTokenToken.test.js
@@ -270,6 +270,33 @@ describe('grant.codeIdTokenToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(codeIdTokenToken(issueToken, issueCode, issueIDToken))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
   describe('decision handling', function() {

--- a/test/grant/codeToken.test.js
+++ b/test/grant/codeToken.test.js
@@ -290,6 +290,34 @@ describe('grant.codeToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('with scope parameter that is not a string', function() {
+      var err, out;
+
+      before(function(done) {
+        chai.oauth2orize.grant(codeToken(issueToken, issueCode))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = 'c123';
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+            req.query.scope = ['read', 'write'];
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: scope must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
   describe('decision handling', function() {

--- a/test/grant/codeToken.test.js
+++ b/test/grant/codeToken.test.js
@@ -263,6 +263,33 @@ describe('grant.codeToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(codeToken(issueToken, issueCode))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
   });
   
   describe('decision handling', function() {

--- a/test/grant/idToken.test.js
+++ b/test/grant/idToken.test.js
@@ -256,6 +256,33 @@ describe('grant.idToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(idToken(issue))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
     
     describe('with scope parameter that is not a string', function() {
        var err, out;

--- a/test/grant/idTokenToken.test.js
+++ b/test/grant/idTokenToken.test.js
@@ -263,6 +263,33 @@ describe('grant.idTokenToken', function() {
         expect(err.code).to.equal('invalid_request');
       });
     });
+
+    describe('request with invalid client_id parameter', function() {
+      var err, out;
+      
+      before(function(done) {
+        chai.oauth2orize.grant(idTokenToken(issueToken, issueIDToken))
+          .req(function(req) {
+            req.query = {};
+            req.query.client_id = ['c123', 'c123'];
+            req.query.redirect_uri = 'http://example.com/auth/callback';
+            req.query.state = 'f1o1o1';
+          })
+          .parse(function(e, o) {
+            err = e;
+            out = o;
+            done();
+          })
+          .authorize();
+      });
+      
+      it('should error', function() {
+        expect(err).to.be.an.instanceOf(Error);
+        expect(err.constructor.name).to.equal('AuthorizationError');
+        expect(err.message).to.equal('Invalid parameter: client_id must be a string');
+        expect(err.code).to.equal('invalid_request');
+      });
+    });
     
     describe('request with scope parameter that is not a string', function() {
       var err, out;


### PR DESCRIPTION
when `&client_id` (or `&scope`) was specified twice, `req.query.client_id` (or `req.query.scope`) is an array